### PR TITLE
fix: Array mutablity description

### DIFF
--- a/src/ch02-02-data-types.md
+++ b/src/ch02-02-data-types.md
@@ -248,14 +248,14 @@ Here is an example of creation of an array with 3 elements:
 use array::ArrayTrait;
 
 fn main() {
-    let mut a = ArrayTrait::new();
+    let a = ArrayTrait::new();
     a.append(0);
     a.append(1);
     a.append(2);
 }
 ```
 
-It is possible to remove an element from the front of an array by calling the `pop_front()` method:
+Arrays can be made mutable by adding `mut` keyword. It is possible to remove an element from the front of an mutable array by calling the `pop_front()` method:
 
 ```rust
 

--- a/src/ch02-02-data-types.md
+++ b/src/ch02-02-data-types.md
@@ -143,7 +143,7 @@ Flow”][control-flow]<!-- ignore --> section.
 #### The Short String Type
 
 Cairo doesn't have a native type for strings, but you can store characters forming what we call a "short string" inside `felt252`s. Here are
-some examples of declaring values by puting them beteen single quotes:
+some examples of declaring values by putting them between single quotes:
 
 ```rust
 let my_first_char = 'C';


### PR DESCRIPTION
The current description is confusing as it suggests arrays are not mutable. The listed examples show how you can pop elements from the front but do not highlight the usage of `mut` keyword.