### PR TITLE
Update ch01-02-hello-world.md

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -65,7 +65,7 @@ _~/cairo_projects/hello_world_ directory. Enter the following
 commands to compile and run the file:
 
 ```console
-$ cairo-run main.cairo
+$ cairo-run -p main.cairo
 Hello, world!
 ```
 


### PR DESCRIPTION
Arg -p or --path is required (cairo-lang-runner 1.0.0-alpha.6) : 

cairo-run main.cairo
error: Found argument 'main.cairo' which wasn't expected, or isn't valid in this context

Usage: cairo-run [OPTIONS] --path <PATH>

For more information try '--help'