### PR TITLE
Update ch02-02-data-types.md

### DIFF
--- a/src/ch02-02-data-types.md
+++ b/src/ch02-02-data-types.md
@@ -11,7 +11,7 @@ when many types are possible, we can use a cast method where we specify the desi
 use traits::TryInto;
 use option::OptionTrait;
 fn main(){
-    let x = 3;
+    let x: felt252 = 3;
     let y:u32 = x.try_into().unwrap();
 }
 ```


### PR DESCRIPTION
The previous code was able to run because the compiler inferred the type of the variable. However, this could be confusing to understand.