### PR TITLE
feat: Enforce cairo-format coding style in mdbook-cairo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,15 @@ The translation work is inspired from [Comprehensive Rust repository](https://gi
 
 ### Work locally (Cairo programs verification)
 
-The current book has a mdbook backend to extract Cairo programs from the markdown sources.
-To run this locally, and test if a Cairo program you have written in the book actually compiled.
+The current book has a mdbook backend to extract Cairo programs from the markdown sources. Currently, for each program it test two things: if it compiles and if it adheres to the `cairo-format` coding style. You can run this locally and test if a Cairo program you have written in the book passes these tests.
 
 The mdbook-cairo backend is working as following:
 1. It takes every code blocks in the markdown source and parse all of them.
 2. Code blocks with a main function `fn main()` are extracted into Cairo programs.
-3. The extracted programs are nammed based on the chapter they belong to, and a consecutive
+3. The extracted programs are named based on the chapter they belong to, and a consecutive
    number of the `fn main()` found in the chapter.
-4. If you have a code block with a `fn main()` function, but you know that is does not compile,
-   you can add an attribute to the code block tag value as following:
+4. If you have a code block with a `fn main()` function that you know does not compile,
+   you can indicate it by adding the `does_not_compile` attribute to the code block, like this:
    
    ````
    ```rust,does_not_compile
@@ -81,8 +80,17 @@ The mdbook-cairo backend is working as following:
    This main function will still count in the consecutive number of `fn main()` in the chapter file,
    but will not be extracted into a Cairo program.
 
-To run the CI locally, ensure that you are at the root of the repository (same directoy of this `README.md` file),
-and run:
+5. Alternatively, if you want to disable the format check using `cairo-format`,
+   you can add the `ignore_format` attribute to the code block, like this:   
+
+   ````
+   ```rust,ignore_format
+   fn main() {
+   }
+   ```
+   ````
+
+To run the CI locally, ensure that you are at the root of the repository (same directory of this `README.md` file), and run:
 
 `bash mdbook-cairo/scripts/cairo_local_verify.sh`
 

--- a/mdbook-cairo/scripts/cairo_programs_verifier.sh
+++ b/mdbook-cairo/scripts/cairo_programs_verifier.sh
@@ -35,7 +35,7 @@ for prog in *.cairo; do
   # Check format if needed
   format_code=0
   if [[ $prog =~ "_checkfmt" ]]; then
-    cairo-format --check "$prog" > output/"$prog".err
+    cairo-format --check --print-parsing-errors "$prog" > output/"$prog".err
     format_code="$?"
   fi
 

--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -80,7 +80,7 @@ program. That makes you a Cairo programmer—welcome!
 Let’s review this “Hello, world!” program in detail. Here’s the first piece of
 the puzzle:
 
-```rust
+```rust,ignore_format
 fn main() {
 
 }

--- a/src/ch02-02-data-types.md
+++ b/src/ch02-02-data-types.md
@@ -10,9 +10,9 @@ when many types are possible, we can use a cast method where we specify the desi
 ```Rust
 use traits::TryInto;
 use option::OptionTrait;
-fn main(){
+fn main() {
     let x: felt252 = 3;
-    let y:u32 = x.try_into().unwrap();
+    let y: u32 = x.try_into().unwrap();
 }
 ```
 
@@ -96,7 +96,7 @@ how you’d use each numeric operation in a `let` statement:
 
 ```rust
 fn main() {
-     // addition
+    // addition
     let sum = 5_u128 + 10_u128;
 
     // subtraction
@@ -165,14 +165,16 @@ use traits::TryInto;
 use traits::Into;
 use option::OptionTrait;
 
-fn main(){
+fn main() {
     let my_felt = 10;
-    let my_u8: u8 = my_felt.try_into().unwrap(); // Since a felt252 might not fit in a u8, we need to unwrap the Option<T> type
+    let my_u8: u8 =
+        my_felt.try_into().unwrap(); // Since a felt252 might not fit in a u8, we need to unwrap the Option<T> type
     let my_u16: u16 = my_felt.try_into().unwrap();
     let my_u32: u32 = my_felt.try_into().unwrap();
     let my_u64: u64 = my_felt.try_into().unwrap();
     let my_u128: u128 = my_felt.try_into().unwrap();
-    let my_u256: u256 = my_felt.into(); // As a felt252 is smaller than a u256, we can use the into() method
+    let my_u256: u256 =
+        my_felt.into(); // As a felt252 is smaller than a u256, we can use the into() method
     let my_usize: usize = my_felt.try_into().unwrap();
     let my_felt2: felt252 = my_u8.into();
     let my_felt3: felt252 = my_u16.into();
@@ -192,7 +194,7 @@ type annotations in this example:
 
 ```rust
 fn main() {
-    let tup: (u32,u64,bool) = (10,20,true);
+    let tup: (u32, u64, bool) = (10, 20, true);
 }
 ```
 

--- a/src/ch02-03-functions.md
+++ b/src/ch02-03-functions.md
@@ -96,10 +96,10 @@ commas, like this:
 use debug::PrintTrait;
 
 fn main() {
-    another_function(5,6);
+    another_function(5, 6);
 }
 
-fn another_function(x: felt252, y:felt252) {
+fn another_function(x: felt252, y: felt252) {
     x.print();
     y.print();
 }
@@ -153,7 +153,7 @@ statement in itself.
 Statements do not return values. Therefore, you can’t assign a `let` statement
 to another variable, as the following code tries to do; you’ll get an error:
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore_format
 fn main() {
     let x = (let y = 6);
 }

--- a/src/ch02-05-control-flow.md
+++ b/src/ch02-05-control-flow.md
@@ -57,7 +57,7 @@ You can use multiple conditions by combining if and else in an else if expressio
 
 <span class="filename">Filename: main.cairo</span>
 
-```rust
+```rust,ignore_format
 use debug::PrintTrait;
 
 fn main() {
@@ -132,10 +132,10 @@ like this:
 ```rust,ignore,does_not_compile
 use debug::PrintTrait;
 fn main() {
-    let mut i:usize = 0;
+    let mut i: usize = 0;
     loop {
-        if i > 10{
-            break();
+        if i > 10 {
+            break ();
         }
         'again!'.print();
     }

--- a/src/ch02-06-common-collections.md
+++ b/src/ch02-06-common-collections.md
@@ -103,11 +103,12 @@ fn main() -> u128 {
     let mut arr = ArrayTrait::<u128>::new();
     arr.append(100_u128);
     let index_to_access =
-        1_usize;        // Change this value to see different results, what would happen if the index doesn't exist ?
+        1_usize; // Change this value to see different results, what would happen if the index doesn't exist ?
     match arr.get(index_to_access) {
         Option::Some(x) => {
-            *x.unbox()  // Don't worry about * for now, if you are curious see Chapter 3.2 #desnap operator
-                        // It basically means "transform what get(idx) returned into a real value"
+            *x.unbox()
+        // Don't worry about * for now, if you are curious see Chapter 3.2 #desnap operator
+        // It basically means "transform what get(idx) returned into a real value"
         },
         Option::None(_) => {
             let mut data = ArrayTrait::new();

--- a/src/ch03-01-what-is-ownership.md
+++ b/src/ch03-01-what-is-ownership.md
@@ -80,11 +80,9 @@ function calls:
 
 ```rust,does_not_compile
 use array::ArrayTrait;
-fn foo(arr: Array<u128>) {
-}
+fn foo(arr: Array<u128>) {}
 
-fn bar(arr:Array<u128>){
-}
+fn bar(arr: Array<u128>) {}
 
 fn main() {
     let mut arr = ArrayTrait::<u128>::new();
@@ -116,7 +114,7 @@ If a type implements the `Copy` trait, passing it to a function will not move th
 You can implement the `Copy` trait on your type by adding the `#[derive(Copy)]` annotation to your type definition. However, Cairo won't allow a type to be annotated with Copy if the type itself or any of its components don't implement the Copy trait.
 While Arrays and Dictionaries can't be copied, custom types that don't contain either of them can be.
 
-```rust
+```rust,ignore_format
 #[derive(Copy, Drop)]
 struct Point {
     x: u128,
@@ -189,9 +187,7 @@ struct A {
 }
 
 fn main() {
-    A {
-        dict: Felt252DictTrait::new()
-    };
+    A { dict: Felt252DictTrait::new() };
 }
 ```
 
@@ -215,9 +211,7 @@ struct A {
 }
 
 fn main() {
-    A {
-        dict: Felt252DictTrait::new()
-    }; // No error here
+    A { dict: Felt252DictTrait::new() }; // No error here
 }
 ```
 
@@ -257,7 +251,7 @@ showing where variables go into and out of scope.
 
 <span class="filename">Filename: src/main.cairo</span>
 
-```rust
+```rust,ignore_format
 #[derive(Drop)]
 struct MyStruct{}
 
@@ -299,15 +293,15 @@ function that returns some value, with similar annotations as those in Listing
 
 <span class="filename">Filename: src/main.cairo</span>
 
-```rust
+```rust,ignore_format
 #[derive(Drop)]
-struct A{}
+struct A {}
 
 fn main() {
     let a1 = gives_ownership();           // gives_ownership moves its return
                                           // value into a1
 
-    let a2 = A{};                         // a2 comes into scope
+    let a2 = A {};                        // a2 comes into scope
 
     let a3 = takes_and_gives_back(a2);    // a2 is moved into
                                           // takes_and_gives_back, which also
@@ -320,7 +314,7 @@ fn gives_ownership() -> A {               // gives_ownership will move its
                                           // return value into the function
                                           // that calls it
 
-    let some_a = A{};                     // some_a comes into scope
+    let some_a = A {};                    // some_a comes into scope
 
     some_a                                // some_a is returned and
                                           // moves ownership to the calling

--- a/src/ch03-02-references-and-snapshots.md
+++ b/src/ch03-02-references-and-snapshots.md
@@ -22,7 +22,7 @@ the `calculate_length` function will not mutate the array, and ownership of the 
 
 <span class="filename">Filename: src/lib.cairo</span>
 
-```rust
+```rust,ignore_format
 use array::ArrayTrait;
 use debug::PrintTrait;
 
@@ -83,17 +83,16 @@ The snapshot type is always copyable and droppable, so that you can use it multi
 ```rust
 use debug::PrintTrait;
 
-#[derive(Copy,Drop)]
+#[derive(Copy, Drop)]
 struct Rectangle {
     height: u64,
     width: u64,
 }
 
-fn main(){
-    let rec = Rectangle{height:3_u64, width:10_u64};
+fn main() {
+    let rec = Rectangle { height: 3_u64, width: 10_u64 };
     let area = calculate_area(@rec);
     area.print();
-
 }
 
 fn calculate_area(rec: @Rectangle) -> u64 {
@@ -111,14 +110,14 @@ Listing 3-6. Spoiler alert: it doesn’t work!
 <span class="filename">Filename: src/lib.cairo</span>
 
 ```rust,does_not_compile
-#[derive(Copy,Drop)]
+#[derive(Copy, Drop)]
 struct Rectangle {
     height: u64,
     width: u64,
 }
 
-fn main(){
-    let rec = Rectangle{height:3_u64, width:10_u64};
+fn main() {
+    let rec = Rectangle { height: 3_u64, width: 10_u64 };
     flip(@rec);
 }
 

--- a/src/ch04-02-an-example-program-using-structs.md
+++ b/src/ch04-02-an-example-program-using-structs.md
@@ -56,7 +56,7 @@ fn main() {
 }
 
 fn area(dimension: (u64, u64)) -> u64 {
-    let (x,y) = dimension;
+    let (x, y) = dimension;
     x * y
 }
 ```
@@ -73,7 +73,7 @@ We use structs to add meaning by labeling the data. We can transform the tuple w
 
 <span class="filename">Filename: src/lib.cairo</span>
 
-```rust
+```rust,ignore_format
 use debug::PrintTrait;
 
 struct Rectangle {
@@ -105,7 +105,7 @@ It’d be useful to be able to print an instance of `Rectangle` while we’re de
 
 <span class="filename">Filename: src/lib.cairo</span>
 
-```rust,does_not_compile
+```rust,does_not_compile,ignore_format
 use debug::PrintTrait;
 
 struct Rectangle {
@@ -141,7 +141,7 @@ To learn more about traits, see [Traits in Cairo](ch07-02-traits-in-cairo.md).
 
 <span class="filename">Filename: src/lib.cairo</span>
 
-```rust
+```rust,ignore_format
 use debug::PrintTrait;
 
 struct Rectangle {

--- a/src/ch06-02-defining-modules-to-control-scope.md
+++ b/src/ch06-02-defining-modules-to-control-scope.md
@@ -94,10 +94,9 @@ use garden::vegetables::Asparagus;
 
 mod garden;
 
-fn main(){
-    let Asparagus = Asparagus{};
+fn main() {
+    let Asparagus = Asparagus {};
 }
-
 
 ```
 

--- a/src/ch06-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch06-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -133,7 +133,7 @@ local name, or _alias_, for the type. Listing 6-9 shows how you can rename an im
 ```rust
 use array::ArrayTrait as Arr;
 
-fn main(){
+fn main() {
     let mut arr = Arr::new(); // ArrayTrait was renamed to Arr
     arr.append(1);
 }

--- a/src/ch07-01-generic-data-types.md
+++ b/src/ch07-01-generic-data-types.md
@@ -59,7 +59,7 @@ Imagine that we want, given a list of elements of some generic type `T`, find th
 
 ```rust,does_not_compile
 // This code does not compile!
-use array:ArrayTrait;
+use array::ArrayTrait;
 
 // Given a list of T get the smallest one.
 // The PartialOrd trait implements comparison operations for T
@@ -73,7 +73,7 @@ fn smallest_element<T, impl TPartialOrd: PartialOrd<T>>(list: @Array<T>) -> T {
 
     // Iterate through the whole list storing the smallest
     loop {
-        if index >= list.len(){
+        if index >= list.len() {
             break smallest;
         }
         if *list[index] < smallest {
@@ -83,7 +83,7 @@ fn smallest_element<T, impl TPartialOrd: PartialOrd<T>>(list: @Array<T>) -> T {
     }
 }
 
-fn main()  {
+fn main() {
     let mut list = ArrayTrait::new();
     list.append(5_u8);
     list.append(3_u8);
@@ -92,7 +92,6 @@ fn main()  {
     // We need to specify that we are passing a snapshot of `list` as an argument
     let s = smallest_element(@list);
     assert(s == 3_u8, 0);
-
 }
 ```
 
@@ -105,7 +104,7 @@ fn smallest_element<T, impl TPartialOrd: PartialOrd<T>, impl TCopy: Copy<T>, imp
     let mut smallest = *list[0_usize];
     let mut index = 1_usize;
     loop {
-        if index >= list.len(){
+        if index >= list.len() {
             break smallest;
         }
         if *list[index] < smallest {
@@ -125,12 +124,12 @@ We can also define structs to use a generic type parameter for one or more field
 
 #[derive(Drop)]
 struct Wallet<T> {
-    balance: T,
+    balance: T
 }
 
 
 fn main() {
-   let w = Wallet{ balance: 3_u128};
+    let w = Wallet { balance: 3_u128 };
 }
 ```
 
@@ -140,7 +139,7 @@ Compiling the above code would error due to the `derive` macro not working well 
 
 ```rust
 struct Wallet<T> {
-    balance: T,
+    balance: T
 }
 
 impl WalletDrop<T, impl TDrop: Drop<T>> of Drop<Wallet<T>>;
@@ -200,7 +199,7 @@ We can implement methods on structs and enums, and use the generic types in thei
 
 ```rust
 struct Wallet<T> {
-    balance: T,
+    balance: T
 }
 
 impl WalletDrop<T, impl TDrop: Drop<T>> of Drop<Wallet<T>>;
@@ -228,8 +227,9 @@ We can also specify constraints on generic types when defining methods on the ty
 
 ```rust
 struct Wallet<T> {
-    balance: T,
+    balance: T
 }
+
 impl WalletDrop<T, impl TDrop: Drop<T>> of Drop<Wallet<T>>;
 impl WalletCopy<T, impl TCopy: Copy<T>> of Copy<Wallet<T>>;
 /// Generic trait for wallets

--- a/src/ch07-02-traits-in-cairo.md
+++ b/src/ch07-02-traits-in-cairo.md
@@ -63,15 +63,15 @@ In the example below, we use generic type `T` and our method signatures can use 
 ```rust
 use debug::PrintTrait;
 
-#[derive(Copy,Drop)]
-struct Rectangle{
+#[derive(Copy, Drop)]
+struct Rectangle {
     height: u64,
     width: u64,
 }
 
-#[derive(Copy,Drop)]
-struct Circle{
-    radius: u64,
+#[derive(Copy, Drop)]
+struct Circle {
+    radius: u64
 }
 
 // Here T is an alias type which will be provided buring implementation
@@ -122,7 +122,7 @@ If `CircleGeometry` was in a separate module/file `circle` then to use `boundary
 
 If the code was organised into modules like this,
 
-```rust, does_not_compile
+```rust,does_not_compile,ignore_format
 use debug::PrintTrait;
 
 // struct Circle { ... } and struct Rectangle { ... }
@@ -142,7 +142,7 @@ mod geometry {
 mod circle {
     use super::geometry::ShapeGeometry;
     use super::Circle;
-    impl CircleGeometry of ShapeGeometry::<Circle> {
+    impl CircleGeometry of ShapeGeometry<Circle> {
         // ...
     }
 }

--- a/src/ch09-01-unrecoverable-errors-with-panic.md
+++ b/src/ch09-01-unrecoverable-errors-with-panic.md
@@ -16,7 +16,7 @@ fn main() {
     let mut data = ArrayTrait::new();
     data.append(2);
     panic(data);
-    'This line isn't reached'.print();
+    'This line isn\'t reached'.print();
 }
 ```
 


### PR DESCRIPTION
Currently, we use mdbook-cairo to detect compilation errors within Cairo code blocks. 

This proposed feature aims to expand the functionality of mdbook-cairo by incorporating `cairo-format` checks to enforce consistent code styling across all Cairo programs (that contain a `fn main()` function). With `cairo-format`, it becomes easier to identify and address minor formatting issues. 

The primary objective of this is to familiarize readers with the official coding style during their learning.
