### PR TITLE
Bash for nondeveloper

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ To work with translations, those are the steps to update the translated content:
 
 The translation work is inspired from [Comprehensive Rust repository](https://github.com/google/comprehensive-rust/blob/main/TRANSLATIONS.md).
 
+#### For non-developer translator
+If you can't set up the environment independently (or don't want to do it), and wish to initiate a new translation for your language, consider the following options:
+- Just ask your progammer friend generate a `.po` file of your language for you.
+- Otherwise, execute the command `./new_language.sh xx` (replace `xx` with your language code). This method can generate a `.po` file and almost doesn't need you install anything by yourself. Only for Linux and MacOS right now.
+
 ### Work locally (Cairo programs verification)
 
 The current book has a mdbook backend to extract Cairo programs from the markdown sources. Currently, for each program it test two things: if it compiles and if it adheres to the `cairo-format` coding style. You can run this locally and test if a Cairo program you have written in the book passes these tests.

--- a/new_language.sh
+++ b/new_language.sh
@@ -1,0 +1,41 @@
+LANG=$1
+FILE=po/$LANG.po
+OS=$(uname)
+
+# Stop if no laguage input.
+if [ $# -eq 0 ]
+then
+    echo ""
+    echo "No input language, exit."
+    exit 0
+fi
+
+#Linux
+if [ "$OS" == "Linux" ]; then
+    ARCH=$(uname -m)
+    # Install gettext
+    sudo apt install gettext
+    # Download mdBook and extract it out
+    if [ "$ARCH" == "aarch64" ]; then
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.30/mdbook-v0.4.30-aarch64-unknown-linux-musl.tar.gz | tar -xz
+    else
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.30/mdbook-v0.4.30-x86_64-unknown-linux-musl.tar.gz | tar -xz
+    fi
+# MACOS
+elif [ "$OS" == "Darwin" ]; then
+    # Install gettext
+    brew install gettext
+    # Download mdBook and extract it out
+    curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.30/mdbook-v0.4.30-x86_64-apple-darwin.tar.gz | tar -xz
+else
+    echo "The operating system is not Linux or macOS."
+    exit 0
+fi
+
+# Build a new LANGUAGES. po file if not exist .
+if test -f "$FILE"; then
+    echo ""
+    echo "File $FILE already exists. Ensure you're building a new book. Alternatively, use 'translations.sh' to serve an existing one."
+else
+    msginit -i po/messages.pot -l $LANG -o po/$LANG.po
+fi

--- a/new_language.sh
+++ b/new_language.sh
@@ -35,7 +35,7 @@ fi
 # Build a new LANGUAGES. po file if not exist .
 if test -f "$FILE"; then
     echo ""
-    echo "File $FILE already exists. Ensure you're building a new book. Alternatively, use 'translations.sh' to serve an existing one."
+    echo "File $FILE already exists. Ensure you're initiating a new translation. Alternatively, use 'translations.sh' to serve an existing one."
 else
     msginit -i po/messages.pot -l $LANG -o po/$LANG.po
 fi


### PR DESCRIPTION
Add a bash for non-developer, who just wants to generate a new `.po` file for translation and doesn't want to set up the environment.
This bash script automatically installs only what's necessary to generate a `.po` file from `message.pot` for a new language, and subsequently runs the `msginit` command to generate that file.
