### PR TITLE
Feat: backend improvements (Compilation, execution, tests, Starknet contracts and format)

### DIFF
--- a/mdbook-cairo/scripts/cairo_local_verify.sh
+++ b/mdbook-cairo/scripts/cairo_local_verify.sh
@@ -33,4 +33,3 @@ sudo docker run --rm \
      --entrypoint sh \
      "$STARKNET_CAIRO_IMAGE" \
      /cairo/cairo_programs_verifier.sh true
-

--- a/mdbook-cairo/scripts/cairo_programs_verifier.sh
+++ b/mdbook-cairo/scripts/cairo_programs_verifier.sh
@@ -7,8 +7,6 @@ RED='\033[1;31m'
 NC='\033[0m'
 
 cd /cairo
-mkdir -p output
-rm -rf output/*
 
 if [ "$IS_RUN_LOCALLY" = true ]; then
     echo -e "\nStarting Cairo programs verifier...\n"
@@ -16,54 +14,81 @@ else
     echo "# Cairo program verifier"
     echo ""
     echo "The list of cairo programs below is auto-generated from the markdown sources."
-    echo "Any code block with a main function will be compiled (except if the attribute does_not_compile is manually added)."
-    echo "Cairo-format is also executed to enforce consistent code style."
     echo ""
 fi
 
-has_error=false
-has_format_error=false
+function run_cairo_checks() {
+    local path="$1"
+    local command="$2"
+    local check_type="$3"
+    error_count=0
 
-for prog in *.cairo; do
-  # Check compilation if needed
-  compile_code=0
-  if [[ "$prog" =~ "_checkcomp" ]]; then
-    cairo-run --available-gas=20000000 "$prog" > output/"$prog".out 2> output/"$prog".err
-    compile_code="$?"
-  fi
+    cd "./$path"
+    mkdir -p output
+    rm -rf output/*
 
-  # Check format if needed
-  format_code=0
-  if [[ $prog =~ "_checkfmt" ]]; then
-    cairo-format --check --print-parsing-errors "$prog" > output/"$prog".err
-    format_code="$?"
-  fi
+    for prog in *.cairo; do
+        if [ "$IS_RUN_LOCALLY" = true ]; then
+            echo -ne "$check_type $prog ...\r"
+        fi
 
-  if [ $compile_code -ne 0 ] || [ $format_code -ne 0 ]; then
-      err="$(cat output/$prog.err)"
-      has_error=true
+        $command "$prog" > output/"$prog".out 2> output/"$prog".err
+        exit_code="$?"
 
-      if [ "$IS_RUN_LOCALLY" = true ]; then
-          echo -e "\n---- ${RED}${prog}${NC} ----\n"
-          echo "$err"
-      else
-          echo ":x: **$prog**"
-          echo "<pre>$err</pre>"
-      fi
+        if [ $exit_code -ne 0 ]; then
+            err="$(cat output/$prog.err)"
+            error_count=$((error_count+1))
 
-      echo ""
-      echo "---  "
-      echo ""
-  fi
+            if [ "$IS_RUN_LOCALLY" = true ]; then
+                echo -ne "---- ${RED}./book/cairo/cairo-programs/$path/${prog}${NC} ----\r\n"
+                echo "$err"
+            else
+                echo ":x: **$prog**"
+                echo "<pre>$err</pre>"
+            fi
+            echo ""
+        fi
+    done
+
+    cd ..
+    return $error_count
+}
+
+# compilable_error=$(run_cairo_checks "compilable" "cairo-compile" "compilation")
+# runnable_error=$(run_cairo_checks "runnable" "cairo-run --available-gas=20000000" "run")
+# testable_error=$(run_cairo_checks "testable" "cairo-test" "test")
+run_cairo_checks "contracts" "starknet-compile" "contract"
+contract_error=$?
+# format_error=$(run_cairo_checks "format" "cairo-format --check --print-parsing-errors" "format")
+
+#has_error=$((has_compilable_error + has_runnable_error + has_testable_error + has_contract_error + has_format_error))
+has_error=$((contract_error))
+
+function print_total() {
+    local section="$1"
+    local error_count="$2"
+    echo -e "$([ $contract_error -eq 0 ] && echo $GREEN || echo $RED)$section: $error_count${NC}"
+}
+
+echo "---"
+echo ""
+echo "Summary:"
+echo ""
+# echo "Compilable: $compilable_error"
+# echo "Runnable: $runnable_error"
+# echo "Test: $testable_error"
+print_total "Contract" $contract_error
+# echo "Format: $format_error"
+echo ""
+print_total "Total" $has_error
+echo ""
 
 
-done
-
-if [ "$has_error" = false ] ; then
+if [ "$has_error" -eq 0 ] ; then
     if [ "$IS_RUN_LOCALLY" = true ]; then
-        echo -e "\n${GREEN}All Cairo programs were compiled successfully and no formatting mistakes were found${NC}.\n"
+        echo -e "\n${GREEN}All checks passed and no problems found!${NC}.\n"
     else
-        echo ":heavy_check_mark: All Cairo programs were compiled successfully and no formatting mistakes were found."
+        echo ":heavy_check_mark:"
         echo ""
     fi
 

--- a/mdbook-cairo/src/main.rs
+++ b/mdbook-cairo/src/main.rs
@@ -150,8 +150,10 @@ fn process_chapter(output_dir: &Path, prefix: &str, content: &str) {
                     let is_contract = text.contains(CODE_BLOCK_IS_CONTRACT);
 
                     if is_contract {
-                        // output to contracts directory
-                        write_to_file(&output_dir.join(CONTRACTS_DIR), prefix, &text, program_counter)
+                        if !tag_does_not_compile {
+                            // output to contracts directory
+                            write_to_file(&output_dir.join(CONTRACTS_DIR), prefix, &text, program_counter)
+                        }
                     } else {
                         let should_be_runnable = text.contains(CODE_BLOCK_IS_RUNNABLE);
                         if !tag_does_not_run && should_be_runnable {

--- a/mdbook-cairo/src/main.rs
+++ b/mdbook-cairo/src/main.rs
@@ -11,17 +11,30 @@ use std::path::Path;
 /// The table header expected in book.toml.
 const CAIRO_CONFIG_TABLE_HEADER: &str = "output.cairo";
 
-/// An attribute added to a code block tag to ignore
-/// the code extraction.
-const CODE_BLOCK_DOES_NOT_COMPILE: &str = "does_not_compile";
+/// An attribute added to a code block tag to ignore the cairo-compile check.
+const TAG_DOES_NOT_COMPILE: &str = "does_not_compile";
+/// An attribute added to a code block tag to ignore the cairo-run check.
+const TAG_DOES_NOT_RUN: &str = "does_not_run";
+/// An attribute added to a code block tag to ignore the cairo-format check.
+const TAG_IGNORE_FORMAT: &str = "ignore_format";
+/// An attribute added to a code block tag to ignore the cairo-format check.
+const TAG_FAILING_TESTS: &str = "test_fails";
+// we assume that every rust code block is a cairo block
+const CAIRO_TAG: &str = "rust";
 
-/// An attribute added to a code block tag to ignore
-/// the format check.
-const CODE_BLOCK_IGNORE_FORMAT: &str = "ignore_format";
+/// Expected statement in a code block for it to be runnable.
+const CODE_BLOCK_IS_RUNNABLE: &str = "fn main()";
+/// Expected statement in a code block for it to be runnable.
+const CODE_BLOCK_IS_CONTRACT: &str = "#[contract]";
+/// Expected statement in a code block containing tests.
+const CODE_BLOCK_IS_TESTABLE: &str = "#[test]";
 
-/// Main function expected in a code block to be a candidate
-/// for the code extraction.
-const CODE_BLOCK_MAIN_FUNCTION: &str = "fn main()";
+/// Configurations for the cairo backend.
+const COMPILABLE_DIR: &str = "compilable";
+const RUNNABLE_DIR: &str = "runnable";
+const TESTABLE_DIR: &str = "testable";
+const CONTRACTS_DIR: &str = "contracts";
+const FORMATS_DIR: &str = "formats";
 
 /// Struct mapping fields expected in [output.cairo] from book.toml.
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -30,7 +43,7 @@ pub struct CairoConfig {
     pub output_dir: String,
 }
 
-// Statically initialize the regex to avoid rebuiling at each loop iteration.
+// Statically initialize the regex to avoid rebuilding at each loop iteration.
 lazy_static! {
     static ref REGEX: Regex =
         Regex::new(r"^ch(\d{2})-(\d{2})-(.*)$").expect("Failed to create regex");
@@ -66,6 +79,15 @@ fn main() {
         .unwrap_or_else(|_| println!("Couldn't clean output directory, skip."));
 
     create_dir_all(output_path).expect("Couldn't create output directory.");
+
+    // Create subdirectories for different types of code blocks
+    let subdirectories = [COMPILABLE_DIR, RUNNABLE_DIR, TESTABLE_DIR, CONTRACTS_DIR, FORMATS_DIR];
+    subdirectories
+        .iter()
+        .for_each(|subdir| {
+            create_dir_all(output_path.join(Path::new(subdir)))
+            .expect("Couldn't create output directory.");
+        });
 
     process_chapters(&ctx.book, &output_path);
 }
@@ -103,46 +125,78 @@ fn process_chapter(output_dir: &Path, prefix: &str, content: &str) {
     let parser = Parser::new(content);
 
     let mut program_counter = 1;
-    let mut in_code_block = false;
-    let mut is_compilable = false;
-    let mut enforce_format = true;
+    let mut is_cairo_block = false;
+
+    // tags
+    let mut tag_does_not_compile = false;
+    let mut tag_does_not_run = false;
+    let mut tag_failing_tests = false;
+    let mut tag_ignore_format = false;
 
     for event in parser {
         match event {
             Event::Start(Tag::CodeBlock(x)) => {
-                in_code_block = true;
-
                 if let CodeBlockKind::Fenced(tag_value) = x {
-                    is_compilable = !tag_value.to_string().contains(CODE_BLOCK_DOES_NOT_COMPILE);
-                    enforce_format = !tag_value.to_string().contains(CODE_BLOCK_IGNORE_FORMAT);
+                    is_cairo_block = tag_value.to_string().contains(CAIRO_TAG);
+
+                    tag_does_not_compile = tag_value.to_string().contains(TAG_DOES_NOT_COMPILE);
+                    tag_does_not_run = tag_value.to_string().contains(TAG_DOES_NOT_RUN);
+                    tag_ignore_format = tag_value.to_string().contains(TAG_IGNORE_FORMAT);
+                    tag_failing_tests = tag_value.to_string().contains(TAG_FAILING_TESTS);
                 }
             }
             Event::Text(text) => {
-                if in_code_block && text.contains(CODE_BLOCK_MAIN_FUNCTION) {
-                    if is_compilable || enforce_format {
-                        let compile_tag = if is_compilable { "_checkcomp" } else { "" };
-                        let format_tag = if enforce_format { "_checkfmt" } else { "" };
-                        let file_name = format!(
-                            "{}_{}{}{}.cairo",
-                            prefix, program_counter, compile_tag, format_tag
-                        );
+                if is_cairo_block {
+                    let is_contract = text.contains(CODE_BLOCK_IS_CONTRACT);
 
-                        let file_dir = &output_dir.join(file_name);
-                        let mut file = File::create(file_dir).expect("Failed to create file.");
-
-                        file.write(text.as_bytes()).expect("Can't write to file.");
+                    if is_contract {
+                        // output to contracts directory
+                        write_to_file(&output_dir.join(CONTRACTS_DIR), prefix, &text, program_counter)
+                    } else {
+                        let should_be_runnable = text.contains(CODE_BLOCK_IS_RUNNABLE);
+                        if !tag_does_not_run && should_be_runnable {
+                            // output to runnable directory
+                            write_to_file(&output_dir.join(RUNNABLE_DIR), prefix, &text, program_counter)
+                        } else if !tag_does_not_compile {
+                            // output to compilable directory
+                            write_to_file(&output_dir.join(COMPILABLE_DIR), prefix, &text, program_counter)
+                        }
                     }
 
-                    // To facilitate the debugging, we always increment the counter when a
-                    // main function is found in a code block. This helps contributors to
-                    // easily locate the code, without having to skip the `does_not_compile` blocks.
+                    let has_tests = text.contains(CODE_BLOCK_IS_TESTABLE);
+                    if !tag_failing_tests && has_tests {
+                        // output to testable directory
+                        write_to_file(&output_dir.join(TESTABLE_DIR), prefix, &text, program_counter)
+                    }
+
+                    if !tag_ignore_format {
+                        // output to formats directory
+                        write_to_file(&output_dir.join(FORMATS_DIR), prefix, &text, program_counter)
+                    }
+
+                    // To facilitate the debugging, we always increment the counter when a cairo code block is found.
+                    // This helps contributors to easily locate code blocks.
                     program_counter += 1;
                 }
             }
             Event::End(Tag::CodeBlock(_)) => {
-                in_code_block = false;
+                is_cairo_block = false;
+
+                // reset tags
+                tag_does_not_compile = false;
+                tag_does_not_run = false;
+                tag_ignore_format = false;
+                tag_failing_tests = false;
             }
             _ => {}
         }
     }
+}
+
+fn write_to_file(output_dir: &Path, prefix: &str, content: &str, program_counter: i32) {
+    let file_name = format!("{}_{}.cairo", prefix, program_counter);
+    let file_dir = &output_dir.join(file_name);
+    let mut file = File::create(file_dir).expect("Failed to create file.");
+
+    file.write(content.as_bytes()).expect("Can't write to file.");
 }


### PR DESCRIPTION
close #189

List of changes:
- Automatically extract Cairo code blocks
- Detect Starknet smart contracts and verify with starknet-compile
- Detect Cairo tests and verify with cairo-test
- Detect runnable Cairo code and verify with cairo-run
- Ensure all other Cairo code is compilable
- Add new tag `does_not_run`
- Add new tag `test_fails`
- Add in-progress tests visualizer for local verifier bash script
- Add clickable path to open the extracted code block (for compatible CLI/IDE)
- Improve tests summary and outputs

Todo:
- [ ] Add README documentation
- [ ] Fix detected errors