### PR TITLE
Fixed field init shorthand

### DIFF
--- a/listings/ch04-using-structs-to-structure-related-data/listing_04_03_mut_struct.cairo
+++ b/listings/ch04-using-structs-to-structure-related-data/listing_04_03_mut_struct.cairo
@@ -23,7 +23,7 @@ fn build_user(email: felt252, username: felt252) -> User {
 
 // ANCHOR: build_user2
 fn build_user_short(email: felt252, username: felt252) -> User {
-    User { active: true, username: username, email: email, sign_in_count: 1,  }
+    User { active: true, username, email, sign_in_count: 1,  }
 }
 // ANCHOR_END: build_user2
 // ANCHOR_END: all


### PR DESCRIPTION
In the current version, both `Listing 4-4` and `Listing 4-5` have identical content. The latter, however, is expected to demonstrate the use of field init shorthand, which is not currently the case.

The current `Listing 4-5` is as follows:
```cairo
fn build_user_short(email: felt252, username: felt252) -> User {
    User { active: true, username: username, email: email, sign_in_count: 1,  }
}
```

To correctly exemplify field init shorthand, I suggest the following revision for `Listing 4-5`:
```cairo
fn build_user_short(email: felt252, username: felt252) -> User {
    User { active: true, username, email, sign_in_count: 1,  }
}
```