### PR TITLE
Fixed dispatcher naming and ownership

### DIFF
--- a/listings/ch99-starknet-smart-contracts/listing_99_05_dispatcher_trait.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_05_dispatcher_trait.cairo
@@ -2,7 +2,7 @@
 use starknet::{ContractAddress};
 
 trait IERC20DispatcherTrait<T> {
-    fn get_name(self: T) -> felt252;
+    fn name(self: T) -> felt252;
     fn transfer(self: T, recipient: ContractAddress, amount: u256);
 }
 
@@ -12,9 +12,12 @@ struct IERC20Dispatcher {
 }
 
 impl IERC20DispatcherImpl of IERC20DispatcherTrait<IERC20Dispatcher> {
-    fn get_name(self: IERC20Dispatcher) -> felt252 {
-        // starknet::call_contract_syscall is called in here
+    fn name(
+        self: IERC20Dispatcher
+    ) -> felt252 { // starknet::call_contract_syscall is called in here
     }
-    fn transfer(self: IERC20Dispatcher, recipient: ContractAddress, amount: u256) {// starknet::call_contract_syscall is called in here
+    fn transfer(
+        self: IERC20Dispatcher, recipient: ContractAddress, amount: u256
+    ) { // starknet::call_contract_syscall is called in here
     }
 }

--- a/listings/ch99-starknet-smart-contracts/listing_99_05_dispatcher_trait.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_05_dispatcher_trait.cairo
@@ -6,7 +6,7 @@ trait IERC20DispatcherTrait<T> {
     fn transfer(self: T, recipient: ContractAddress, amount: u256);
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, storage_access::StorageAccess, Serde)]
 struct IERC20Dispatcher {
     contract_address: starknet::ContractAddress, 
 }

--- a/listings/ch99-starknet-smart-contracts/listing_99_07_library_dispatcher.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_07_library_dispatcher.cairo
@@ -6,7 +6,7 @@ trait IERC20DispatcherTrait<T> {
     fn transfer(self: T, recipient: ContractAddress, amount: u256);
 }
 
-#[derive(Copy, Drop)]
+#[derive(Copy, Drop, storage_access::StorageAccess, Serde)]
 struct IERC20LibraryDispatcher {
     class_hash: starknet::ClassHash, 
 }

--- a/listings/ch99-starknet-smart-contracts/listing_99_07_library_dispatcher.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_07_library_dispatcher.cairo
@@ -1,7 +1,8 @@
 //does_not_compile
 use starknet::ContractAddress;
+
 trait IERC20DispatcherTrait<T> {
-    fn get_name(self: T) -> felt252;
+    fn name(self: T) -> felt252;
     fn transfer(self: T, recipient: ContractAddress, amount: u256);
 }
 
@@ -11,8 +12,12 @@ struct IERC20LibraryDispatcher {
 }
 
 impl IERC20LibraryDispatcherImpl of IERC20DispatcherTrait<IERC20LibraryDispatcher> {
-    fn get_name(self: IERC20LibraryDispatcher) -> felt252 {// starknet::syscalls::library_call_syscall  is called in here
+    fn name(
+        self: IERC20LibraryDispatcher
+    ) -> felt252 { // starknet::syscalls::library_call_syscall  is called in here
     }
-    fn transfer(self: IERC20LibraryDispatcher, recipient: ContractAddress, amount: u256) {// starknet::syscalls::library_call_syscall  is called in here
+    fn transfer(
+        self: IERC20LibraryDispatcher, recipient: ContractAddress, amount: u256
+    ) { // starknet::syscalls::library_call_syscall  is called in here
     }
 }


### PR DESCRIPTION
Currently, the documentation indicates that the `IERC20Dispatcher` struct implements a method called `get_name` (`Listing 99-2`), while `Listing 99-3` suggests that a method called `name` should be implemented instead. The same discrepancy is observed in `LibraryDispatcher` (`Listing 99-4`).

Furthermore, it's expected that the dispatcher structs instances can be used multiple times, indicating that the implemented methods should not take ownership. However, `Listing 99-2`and `Listing 99-4` suggests that these methods take ownership, which would prohibit their multiple uses. To address this, I propose that the methods should be revised to receive a snapshot as a parameter, thereby not taking ownership.