### PR TITLE
Improvements to the Contract Dispatchers section

### DIFF
--- a/listings/ch99-starknet-smart-contracts/listing_99_06_sample_contract.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_06_sample_contract.cairo
@@ -39,7 +39,7 @@ trait ITokenWrapper<TContractState> {
 //ANCHOR: here
 //**** Specify interface here ****//
 #[starknet::contract]
-mod token_wrapper {
+mod TokenWrapper {
     use super::IERC20DispatcherTrait;
     use super::IERC20Dispatcher;
     use super::ITokenWrapper;

--- a/listings/ch99-starknet-smart-contracts/listing_99_08_using_library_dispatcher.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_08_using_library_dispatcher.cairo
@@ -33,7 +33,7 @@ trait ITokenWrapper<TContractState> {
 
 //ANCHOR: here
 #[starknet::contract]
-mod token_wrapper {
+mod TokenWrapper {
     use super::IERC20DispatcherTrait;
     use super::IERC20LibraryDispatcher;
     use starknet::ContractAddress;

--- a/src/ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md
+++ b/src/ch99-02-02-contract-dispatcher-library-dispatcher-and-system-calls.md
@@ -25,7 +25,7 @@ It's also worthy of note that all these are abstracted behind the scenes thanks 
 
 ### Calling Contracts using the Contract Dispatcher
 
-This is an example of a contract named `Dispatcher` using the Contract interface dispatcher to call an ERC-20 contract in the ERC-20 contract's context and, in the case of `transfer_token`, altering the state of the ERC-20 contract:
+This is an example of a contract named `TokenWrapper` using the contract interface dispatcher to call an ERC-20, altering the target contract state in the case of `transfer_token`:
 
 ```rust
 {{#rustdoc_include ../listings/ch99-starknet-smart-contracts/listing_99_06_sample_contract.cairo:here}}
@@ -33,11 +33,11 @@ This is an example of a contract named `Dispatcher` using the Contract interface
 
 <span class="caption">Listing 99-6: A sample contract which uses the Contract Dispatcher</span>
 
-As you can see, we had to first import the `IERC20DispatcherTrait` and `IERC20Dispatcher` which was generated and exported on compiling our interface, then we make calls to the methods implemented for the `IERC20Dispatcher` struct (`name`, `transfer`, etc), passing in the `contract_address` parameter which represents the address of the contract we want to call.
+As you can see, we had to first import the `IERC20DispatcherTrait` and `IERC20Dispatcher` which were generated and exported after compiling our interface, then we make calls to the methods implemented for the `IERC20Dispatcher` struct (`name`, `transfer`, etc), passing in the `contract_address` of the contract we want to call.
 
 ## Library Dispatcher
 
-The key difference between the contract dispatcher and the library dispatcher is that while the contract dispatcher calls an external contract's logic in the external contract's context, the library dispatcher calls the target contract's classhash, whilst executing the call in the calling contract's context.
+The key difference between the contract dispatcher and the library dispatcher is that while the contract dispatcher calls an external contract's logic in the external contract's context, the library dispatcher calls the target contract's class hash, whilst executing the call in the calling contract's context.
 So unlike the contract dispatcher, calls made using the library dispatcher have no possibility of tampering with the target contract's state.
 
 As stated in the previous chapter, contracts annotated with the `#[abi]` macro on compilation generates a new trait, two new structs (one for contract calls, and the other for library calls) and their implementation of this trait. The expanded form of the library traits looks like:
@@ -45,6 +45,8 @@ As stated in the previous chapter, contracts annotated with the `#[abi]` macro o
 ```rust
 {{#include ../listings/ch99-starknet-smart-contracts/listing_99_07_library_dispatcher.cairo}}
 ```
+
+Notice that the main difference between the regular contract dispatcher and the library dispatcher is that the former is generated with `call_contract_syscall` while the latter uses `library_call_syscall`.
 
 <span class="caption">Listing 99-7: An expanded form of the IERC20 trait</span>
 
@@ -58,7 +60,7 @@ Below's a sample code on calling contracts using the Library Dispatcher:
 
 <span class="caption">Listing 99-8: A sample contract using the Library Dispatcher</span>
 
-As you can see, we had to first import the `IERC20DispatcherTrait` and `IERC20LibraryDispatcher` which was generated and exported on compiling our interface, then we make calls to the methods implemented for the `IERC20LibraryDispatcher` struct (`name`, `transfer`, etc), passing in the `class_hash` parameter which represents the class of the contract we want to call.
+As you can see, we had to first import the `IERC20DispatcherTrait` and `IERC20LibraryDispatcher` which were generated and exported after compiling our interface, then we make calls to the methods implemented for the `IERC20LibraryDispatcher` struct (`name`, `transfer`, etc), passing in the `class_hash` of the contract we want to call.
 
 ## Calling Contracts using low-level System calls
 


### PR DESCRIPTION
This PR suggests some readability improvements on top of consistent and standard-conforming contract naming.