### PR TITLE
Broken scarb installation link fix

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1205,7 +1205,7 @@ msgstr "### Instalación"
 
 #: src/ch01-03-hello-scarb.md:19
 msgid ""
-"To install Scarb, please refer to the [installation instructions](https://docs.swmansion.com/scarb/docs/install).\n"
+"To install Scarb, please refer to the [installation instructions](https://docs.swmansion.com/scarb/download).\n"
 "You can simply run the following command in your terminal, then follow the onscreen instructions. This will install the latest stable release."
 msgstr ""
 "Para instalar Scarb, por favor consulta las [instrucciones de instalación](https://docs.swmansion.com/scarb/docs/install).\n"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1087,7 +1087,7 @@ msgstr ""
 #: src/ch01-03-hello-scarb.md:19
 msgid ""
 "To install Scarb, please refer to the [installation "
-"instructions](https://docs.swmansion.com/scarb/docs/install).\n"
+"instructions](https://docs.swmansion.com/scarb/download).\n"
 "You can simply run the following command in your terminal, then follow the "
 "onscreen instructions. This will install the latest stable release."
 msgstr ""

--- a/po/zh-cn.po
+++ b/po/zh-cn.po
@@ -1158,7 +1158,7 @@ msgstr "### 安装"
 
 #: src/ch01-03-hello-scarb.md:19
 msgid ""
-"To install Scarb, please refer to the [installation instructions](https://docs.swmansion.com/scarb/docs/install).\n"
+"To install Scarb, please refer to the [installation instructions](https://docs.swmansion.com/scarb/download).\n"
 "You can simply run the following command in your terminal, then follow the onscreen instructions. This will install the latest stable release."
 msgstr ""
 "要安装Scarb，请参考[安装说明]（https://docs.swmansion.com/scarb/docs/install）。\n"

--- a/src/ch01-03-hello-scarb.md
+++ b/src/ch01-03-hello-scarb.md
@@ -16,7 +16,7 @@ Scarb requires a Git executable to be available in the `PATH` environment variab
 
 ### Installation
 
-To install Scarb, please refer to the [installation instructions](https://docs.swmansion.com/scarb/docs/install).
+To install Scarb, please refer to the [installation instructions](https://docs.swmansion.com/scarb/download).
 You can simply run the following command in your terminal, then follow the onscreen instructions. This will install the latest stable release.
 
 ```bash


### PR DESCRIPTION
This PR fixes a broken link for the scarb installation process

<img width="570" alt="image" src="https://github.com/cairo-book/cairo-book.github.io/assets/58019353/2b713932-4b42-4b9c-9a3c-aa6967f49382">
