### PR TITLE
Update ch01-02-hello-world.md to fix the command adding `--single-file`

### DIFF
--- a/src/ch01-02-hello-world.md
+++ b/src/ch01-02-hello-world.md
@@ -65,7 +65,7 @@ _~/cairo_projects/hello_world_ directory. Enter the following
 commands to compile and run the file:
 
 ```console
-$ cairo-run main.cairo
+$ cairo-run --single-file main.cairo
 Hello, world!
 ```
 


### PR DESCRIPTION
Following the instructions and running only `cargo-run main.cairo` will output an error saying `Error: The given path is a file, but --single-file was not supplied.`. So for that case it's necessary to run `cargo-run --single-file main.cairo`