### PR TITLE
Fix invalid mut type conversion example

### DIFF
--- a/listings/ch02-common-programming-concepts/no_listing_05_mut_cant_change_type/src/lib.cairo
+++ b/listings/ch02-common-programming-concepts/no_listing_05_mut_cant_change_type/src/lib.cairo
@@ -1,3 +1,4 @@
+//TAG: does_not_compile
 use debug::PrintTrait;
 use traits::Into;
 fn main() {

--- a/listings/ch02-common-programming-concepts/no_listing_05_mut_cant_change_type/src/lib.cairo
+++ b/listings/ch02-common-programming-concepts/no_listing_05_mut_cant_change_type/src/lib.cairo
@@ -1,8 +1,8 @@
 use debug::PrintTrait;
 use traits::Into;
 fn main() {
-    let mut x = 2;
+    let mut x: u32 = 2;
     x.print();
-    x = x.into();
+    x = 100_felt252;
     x.print()
 }

--- a/src/ch02-01-variables-and-mutability.md
+++ b/src/ch02-01-variables-and-mutability.md
@@ -199,10 +199,10 @@ The error says we were expecting a `u64` (the original type) but we got a differ
 
 ```shell
 $ scarb cairo-run
-error: Unexpected argument type. Expected: "core::integer::u64", found: "core::felt252".
- --> lib.cairo:6:9
-    x = x.into();
-        ^******^
+error: Unexpected argument type. Expected: "core::integer::u32", found: "core::felt252".
+ --> lib.cairo:9:9
+    x = 100_felt252;
+        ^*********^
 
 Error: failed to compile: src/lib.cairo
 ```


### PR DESCRIPTION
The example given to demonstrate that a mut variable cannot change type no
longer produces the error expected from the compiler since the compiler's
type inference has improved in later versions. Instead of `.into` attempting to
convert `x` into a `felt252` it infers that the minimal required change is to
do nothing and preserve the source type. To fix this we force the issue in the
example by specifying a literal of a fixed type.
