### PR TITLE
Fix Name Registry contract

### DIFF
--- a/listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_03_example_contract/src/lib.cairo
@@ -59,7 +59,7 @@ mod NameRegistry {
         fn store_name(ref self: ContractState, name: felt252) {
             let caller = get_caller_address();
             //ANCHOR: write
-            self.names.write(caller, name);
+            self._store_name(caller, name);
         //ANCHOR_END: write
 
         }


### PR DESCRIPTION
Name Registry contract external function `store_name` should call internal function `_store_name`. 