### PR TITLE
Fixed code snippets in `array!` macro chapter

### DIFF
--- a/listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo
+++ b/listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo
@@ -6,5 +6,5 @@ fn main() {
     arr.append(4);
     arr.append(5);
 
-    let mut arr_macro = array![1, 2, 3, 4, 5];
+    let arr = array![1, 2, 3, 4, 5];
 }

--- a/src/ch10-02-macros.md
+++ b/src/ch10-02-macros.md
@@ -10,13 +10,13 @@ At compile-time, the compiler will create an array and append all values passed 
 Without `array!`:
 
 ```rust
-{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:4:9}}
+{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:2:7}}
 ```
 
 With `array!`:
 
 ```rust
-{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:11:11}}
+{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:9:9}}
 ```
 
 ### `consteval_int!`


### PR DESCRIPTION
This is how the `array!` code snippet currently looks like:

![Screenshot 2023-09-11 at 4 53 34 PM](https://github.com/cairo-book/cairo-book.github.io/assets/2279046/05054678-a703-4944-84f8-e92d7d78fe75)

This is how it looks like with the fix:

![Screenshot 2023-09-11 at 4 53 45 PM](https://github.com/cairo-book/cairo-book.github.io/assets/2279046/a8631fb5-ae9a-43a5-b9bd-a98fcb7b5f94)