### PR TITLE
fix: code snippets lines

### DIFF
--- a/listings/ch02-common-programming-concepts/no_listing_19_blocks_are_expressions/src/lib.cairo
+++ b/listings/ch02-common-programming-concepts/no_listing_19_blocks_are_expressions/src/lib.cairo
@@ -1,9 +1,13 @@
+//ANCHOR: all
 use debug::PrintTrait;
 fn main() {
+    //ANCHOR: block_expr
     let y = {
         let x = 3;
         x + 1
     };
+    //ANCHOR_END: block_expr
 
     y.print();
 }
+//ANCHOR_END: all

--- a/listings/ch03-understanding-ownership/no_listing_09_snapshots/src/lib.cairo
+++ b/listings/ch03-understanding-ownership/no_listing_09_snapshots/src/lib.cairo
@@ -7,7 +7,9 @@ fn main() {
     let first_length = calculate_length(
         first_snapshot
     ); // Calculate the length of the array when the snapshot was taken
+    //ANCHOR: function_call
     let second_length = calculate_length(@arr1); // Calculate the current length of the array
+    //ANCHOR_END: function_call
     first_length.print();
     second_length.print();
 }

--- a/listings/ch04-using-structs-to-structure-related-data/listing_04_06_no_struct/src/lib.cairo
+++ b/listings/ch04-using-structs-to-structure-related-data/listing_04_06_no_struct/src/lib.cairo
@@ -1,3 +1,4 @@
+//ANCHOR:all
 use debug::PrintTrait;
 fn main() {
     let width1 = 30;
@@ -6,6 +7,9 @@ fn main() {
     area.print();
 }
 
+//ANCHOR: here
 fn area(width: u64, height: u64) -> u64 {
+//ANCHOR_END: here
     width * height
 }
+//ANCHOR_END:all

--- a/listings/ch04-using-structs-to-structure-related-data/listing_04_10_print_rectangle/src/lib.cairo
+++ b/listings/ch04-using-structs-to-structure-related-data/listing_04_10_print_rectangle/src/lib.cairo
@@ -1,3 +1,5 @@
+//ANCHOR:all
+//ANCHOR: here
 use debug::PrintTrait;
 
 struct Rectangle {
@@ -9,6 +11,7 @@ fn main() {
     let rectangle = Rectangle { width: 30, height: 10, };
     rectangle.print();
 }
+//ANCHOR_END: here
 
 impl RectanglePrintImpl of PrintTrait<Rectangle> {
     fn print(self: Rectangle) {
@@ -16,3 +19,4 @@ impl RectanglePrintImpl of PrintTrait<Rectangle> {
         self.height.print();
     }
 }
+//ANCHOR_END:all

--- a/listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo
+++ b/listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo
@@ -1,9 +1,14 @@
+//ANCHOR:all
 use debug::PrintTrait;
 
 fn plus_one(x: Option<u8>) -> Option<u8> {
     match x {
+        //ANCHOR: option_some
         Option::Some(val) => Option::Some(val + 1),
+        //ANCHOR_END: option_some
+        // ANCHOR: option_none
         Option::None(_) => Option::None,
+    //ANCHOR_END: option_none
     }
 }
 
@@ -14,3 +19,5 @@ fn main() {
     let none = plus_one(Option::None);
     none.unwrap().print();
 }
+//ANCHOR_END:all
+

--- a/listings/ch07-generic-types-and-traits/no_listing_12_not_compiling/src/lib.cairo
+++ b/listings/ch07-generic-types-and-traits/no_listing_12_not_compiling/src/lib.cairo
@@ -1,9 +1,12 @@
 //TAG: does_not_compile
+//ANCHOR: struct
 struct Wallet<T, U> {
     balance: T,
     address: U,
 }
+//ANCHOR_END: struct
 
+//ANCHOR:trait_impl
 // This does not compile!
 trait WalletMixTrait<T1, U1> {
     fn mixup<T2, U2>(self: Wallet<T1, U1>, other: Wallet<T2, U2>) -> Wallet<T1, U2>;
@@ -14,3 +17,5 @@ impl WalletMixImpl<T1, U1> of WalletMixTrait<T1, U1> {
         Wallet { balance: self.balance, address: other.address }
     }
 }
+//ANCHOR_END: trait_impl
+

--- a/listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo
+++ b/listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo
@@ -1,10 +1,14 @@
 fn main() {
+    //ANCHOR: no_macro
     let mut arr = ArrayTrait::new();
     arr.append(1);
     arr.append(2);
     arr.append(3);
     arr.append(4);
     arr.append(5);
+    //ANCHOR_END: no_macro
 
+//ANCHOR: array_macro
     let arr = array![1, 2, 3, 4, 5];
+//ANCHOR_END: array_macro
 }

--- a/src/ch02-03-functions.md
+++ b/src/ch02-03-functions.md
@@ -178,15 +178,13 @@ expression. A new scope block created with
 curly brackets is an expression, for example:
 
 ```rust
-{{#include ../listings/ch02-common-programming-concepts/no_listing_19_blocks_are_expressions/src/lib.cairo}}
+{{#include ../listings/ch02-common-programming-concepts/no_listing_19_blocks_are_expressions/src/lib.cairo:all}}
 ```
 
 This expression:
 
 ```rust, noplayground
-{
-{{#include ../listings/ch02-common-programming-concepts/no_listing_19_blocks_are_expressions/src/lib.cairo:4:5}}
-}
+{{#include ../listings/ch02-common-programming-concepts/no_listing_19_blocks_are_expressions/src/lib.cairo:block_expr}}
 ```
 
 is a block that, in this case, evaluates to `4`. That value gets bound to `y`

--- a/src/ch02-99-01-arrays.md
+++ b/src/ch02-99-01-arrays.md
@@ -95,5 +95,5 @@ All methods provided by `Array` can also be used with `Span`, with the exception
 To create a `Span` of an `Array`, call the `span()` method:
 
 ```rust
-{{#rustdoc_include ../listings/ch02-99-common-collections/no_listing_05_array_span/src/lib.cairo:5}}
+{{#rustdoc_include ../listings/ch02-99-common-collections/no_listing_05_array_spano_listing_05_array_spann/src/lib.cairo:3}}
 ```

--- a/src/ch03-01-what-is-ownership.md
+++ b/src/ch03-01-what-is-ownership.md
@@ -65,7 +65,7 @@ is unknown at compile time and which can't be trivially copied?
 Here is a short reminder of what an array looks like:
 
 ```rust
-{{#rustdoc_include ../listings/ch03-understanding-ownership/no_listing_01_array/src/lib.cairo:3:5}}
+{{#rustdoc_include ../listings/ch03-understanding-ownership/no_listing_01_array/src/lib.cairo:2:4}}
 ```
 
 So, how does the ownership system ensure that each cell is never written to more than once?

--- a/src/ch03-02-references-and-snapshots.md
+++ b/src/ch03-02-references-and-snapshots.md
@@ -44,7 +44,7 @@ that we pass `@arr1` into `calculate_length` and, in its definition, we take `@A
 Let’s take a closer look at the function call here:
 
 ```rust
-{{#rustdoc_include ../listings/ch03-understanding-ownership/no_listing_09_snapshots/src/lib.cairo:11}}
+{{#rustdoc_include ../listings/ch03-understanding-ownership/no_listing_09_snapshots/src/lib.cairo:function_call}}
 ```
 
 The `@arr1` syntax lets us create a snapshot of the value in `arr1`. Because a snapshot is an immutable view of a value, the value it points to cannot be modified through the snapshot, and the value it refers to will not be dropped once the snapshot stops being used.

--- a/src/ch04-02-an-example-program-using-structs.md
+++ b/src/ch04-02-an-example-program-using-structs.md
@@ -7,7 +7,7 @@ Let’s make a new project with Scarb called _rectangles_ that will take the wid
 <span class="filename">Filename: src/lib.cairo</span>
 
 ```rust
-{{#include ../listings/ch04-using-structs-to-structure-related-data/listing_04_06_no_struct/src/lib.cairo}}
+{{#include ../listings/ch04-using-structs-to-structure-related-data/listing_04_06_no_struct/src/lib.cairo:all}}
 ```
 
 <span class="caption">Listing 4-6: Calculating the area of a rectangle specified by separate width and height variables</span>
@@ -26,10 +26,10 @@ This code succeeds in figuring out the area of the rectangle by calling the `are
 The issue with this code is evident in the signature of `area`:
 
 ```rust,noplayground
-{{#include ../listings/ch04-using-structs-to-structure-related-data/listing_04_06_no_struct/src/lib.cairo:9}}
+{{#include ../listings/ch04-using-structs-to-structure-related-data/listing_04_06_no_struct/src/lib.cairo:here}}
 ```
 
-The `area` function is supposed to calculate the area of one rectangle, but the function we wrote has two parameters, and it’s not clear anywhere in our program that the parameters are related. It would be more readable and more manageable to group width and height together. We’ve already discussed one way we might do that in [Chapter 3](ch02-02-data-types.html#the-tuple-type): using tuples.
+The `area` function is supposed to calculate the area of one rectangle, but the function we wrote has two parameters, and it’s not clear anywhere in our program that the parameters are related. It would be more readable and more manageable to group width and height together. We’ve already discussed one way we might do that in [Chapter 2](ch02-02-data-types.html#the-tuple-type): using tuples.
 
 ## Refactoring with Tuples
 
@@ -68,7 +68,7 @@ It’d be useful to be able to print an instance of `Rectangle` while we’re de
 <span class="filename">Filename: src/lib.cairo</span>
 
 ```rust
-{{#include ../listings/ch04-using-structs-to-structure-related-data/listing_04_10_print_rectangle/src/lib.cairo:0:11}}
+{{#include ../listings/ch04-using-structs-to-structure-related-data/listing_04_10_print_rectangle/src/lib.cairo:here}}
 ```
 
 <span class="caption">Listing 4-9: Attempting to print a `Rectangle` instance</span>
@@ -91,7 +91,7 @@ To learn more about traits, see [Traits in Cairo](ch07-02-traits-in-cairo.md).
 <span class="filename">Filename: src/lib.cairo</span>
 
 ```rust
-{{#rustdoc_include ../listings/ch04-using-structs-to-structure-related-data/listing_04_10_print_rectangle/src/lib.cairo}}
+{{#rustdoc_include ../listings/ch04-using-structs-to-structure-related-data/listing_04_10_print_rectangle/src/lib.cairo:all}}
 ```
 
 <span class="caption">Listing 4-10: Implementing the `PrintTrait` trait on `Rectangle`</span>

--- a/src/ch05-02-the-match-control-flow-construct.md
+++ b/src/ch05-02-the-match-control-flow-construct.md
@@ -67,7 +67,7 @@ Let’s say we want to write a function that takes an `Option<u8>` and, if there
 This function is very easy to write, thanks to match, and will look like Listing 5-5.
 
 ```rust
-{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo}}
+{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:all}}
 ```
 
 <span class="caption">Listing 5-5: A function that uses a match
@@ -85,7 +85,7 @@ enum Option<T> {
 Let’s examine the first execution of `plus_one` in more detail. When we call `plus_one(five)`, the variable `x` in the body of `plus_one` will have the value `Some(5)`. We then compare that against each match arm:
 
 ```rust,noplayground
-{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:6}}
+{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:option_some}}
 ```
 
 Does `Option::Some(5)` value match the pattern `Option::Some(val)`? It does! We have the same variant. The `val` binds to the value contained in `Option::Some`, so `val` takes the value `5`. The code in the match arm is then executed, so we add `1` to the value of `val` and create a new `Option::Some` value with our total `6` inside. Because the first arm matched, no other arms are compared.
@@ -93,13 +93,13 @@ Does `Option::Some(5)` value match the pattern `Option::Some(val)`? It does! We 
 Now let’s consider the second call of `plus_one` in our main function, where `x` is `Option::None(())`. We enter the match and compare to the first arm:
 
 ```rust,noplayground
-{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:6}}
+{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:option_some}}
 ```
 
 The `Option::Some(val)` value doesn’t match the pattern `Option::None`, so we continue to the next arm:
 
 ```rust
-{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:7}}
+{{#include ../listings/ch05-enums-and-pattern-matching/listing_05_05/src/lib.cairo:option_none}}
 ```
 
 It matches! There’s no value to add to, so the program stops and returns the `Option::None(())` value on the right side of `=>`.

--- a/src/ch07-01-generic-data-types.md
+++ b/src/ch07-01-generic-data-types.md
@@ -99,13 +99,13 @@ The new method `receive` increments the size of the balance of any instance of a
 Cairo allows us to define generic methods inside generic traits as well. Using the past implementation from `Wallet<U, V>` we are going to define a trait that picks two wallets of different generic types and create a new one with a generic type of each. First, let's rewrite the struct definition:
 
 ```rust,noplayground
-{{#include ../listings/ch07-generic-types-and-traits/no_listing_12_not_compiling/src/lib.cairo:1:4}}
+{{#include ../listings/ch07-generic-types-and-traits/no_listing_12_not_compiling/src/lib.cairo:struct}}
 ```
 
 Next we are going to naively define the mixup trait and implementation:
 
 ```rust,noplayground
-{{#include ../listings/ch07-generic-types-and-traits/no_listing_12_not_compiling/src/lib.cairo:6:15}}
+{{#include ../listings/ch07-generic-types-and-traits/no_listing_12_not_compiling/src/lib.cairo:trait_impl}}
 
 ```
 

--- a/src/ch10-02-macros.md
+++ b/src/ch10-02-macros.md
@@ -10,13 +10,13 @@ At compile-time, the compiler will create an array and append all values passed 
 Without `array!`:
 
 ```rust
-{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:2:7}}
+{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:no_macro}}
 ```
 
 With `array!`:
 
 ```rust
-{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:9:9}}
+{{#include ../listings/ch10-advanced-features/no_listing_02_array_macro/src/lib.cairo:array_macro}}
 ```
 
 ### `consteval_int!`


### PR DESCRIPTION
Closes #359 

A bunch of modifications for the book to reflect the correct source code lines in the `.cairo` files after the v2 refactor