### PR TITLE
Dispatcher example code sanity changes

### DIFF
--- a/listings/ch99-starknet-smart-contracts/listing_99_05_dispatcher_trait/src/lib.cairo
+++ b/listings/ch99-starknet-smart-contracts/listing_99_05_dispatcher_trait/src/lib.cairo
@@ -8,7 +8,7 @@ trait IERC20DispatcherTrait<T> {
 
 #[derive(Copy, Drop, starknet::Store, Serde)]
 struct IERC20Dispatcher {
-    contract_address: starknet::ContractAddress,
+    contract_address: ContractAddress,
 }
 
 impl IERC20DispatcherImpl of IERC20DispatcherTrait<IERC20Dispatcher> {


### PR DESCRIPTION
`ContractAddress` already brought scope from starknet crate and other places in contract as well simply used as `ContractAddress`