### PR TITLE
Update WASM-Cairo to v0.4.0 to support Cairo v2.2.0

### DIFF
--- a/theme/pkg/README.md
+++ b/theme/pkg/README.md
@@ -28,19 +28,6 @@ wasm-pack build --release --target no-modules --out-dir ./pkg/no_module --out-na
 
 You will find `wasm-cairo_bg.wasm` and `wasm-cairo.js` in `pkg` folder.
 
-
-### 🛠️ Build Astro Editor
-
-```
-wasm-pack build --release --target no-modules --out-dir ./dist/pkg --out-name wasm-cairo
-```
-
-Then run 
-```
-node app.js
-```
-For local web instance.
-
 ### 🛠️ Build WASMTIME's WASM-Cairo Toolkit
 
 ```

--- a/theme/pkg/package.json
+++ b/theme/pkg/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "cryptonerdcn <cryptonerdcn@gmail.com>"
   ],
-  "version": "0.2.1",
+  "version": "0.4.0",
   "files": [
     "wasm-cairo_bg.wasm",
     "wasm-cairo.js",

--- a/theme/pkg/wasm-cairo.js
+++ b/theme/pkg/wasm-cairo.js
@@ -265,7 +265,7 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_log_65d0b624a75fcb22 = function(arg0, arg1) {
+    imports.wbg.__wbg_log_9b2c8c4ceb28b489 = function(arg0, arg1) {
         console.log(getStringFromWasm0(arg0, arg1));
     };
 


### PR DESCRIPTION
As title. 
BTW, from Cairo 2.10, it has changed _print_ hint to this format(Print hex value, and no ` )` anymore. )
```
[DEBUG]	                              	(raw: 0x5
[DEBUG]	                              	(raw: 0x6
Run completed successfully, returning []
```
So maybe we need to change some content in the book for this new print format.

You can find more about WASM-Cairo 0.4.0 [here](https://github.com/cryptonerdcn/wasm-cairo/releases/tag/v0.4.0).