### PR TITLE
Update ch06-00-enums-and-pattern-matching.md

### DIFF
--- a/src/ch06-00-enums-and-pattern-matching.md
+++ b/src/ch06-00-enums-and-pattern-matching.md
@@ -1,1 +1,6 @@
 # Enums and Pattern Matching
+Enums which are also known as enumerations, are a natively supported data type in Cairo. Cairo provides a powerful and expressive way to define enums, making them an integral part of the language. Enums define a set of distinct elements or options, they are used to improve code readability, maintainability and also to make it easier to work with a fixed set of related constants. Enums combined with other constructs like the match countrol flow can be used for various purposes, including creating custom data types and modeling different states and options. 
+
+The match control flow is a powerful and flexible way to compare a value against a set of patterns and execute certain logics based on the matched pattern. With a combination of enums and match control flow powerful and complex implementations could be modeled and designed for tasks like enum variant handling, value extraction and control flow.
+
+In this chapter we’ll demonstrate how to define Enums, implement Traits for enums, pattern matching and its application with enums.


### PR DESCRIPTION
Added a brief introduction to chapter 6 landing page. This page is supposed to contain a brief overview and introduction to the subtopics covered in chapter 6 but is currently empty. I believe this little contribution will help readers get an overhead understanding of what the chapter entails and why the two subtopics were grouped together.