### PR TITLE
Update ch06-00-enums-and-pattern-matching.md

### DIFF
--- a/src/ch06-00-enums-and-pattern-matching.md
+++ b/src/ch06-00-enums-and-pattern-matching.md
@@ -1,1 +1,7 @@
 # Enums and Pattern Matching
+In this chapter, we’ll look at enumerations, also referred to as enums and pattern matching.
+
+Enums allow you to define a type by creating a collection possible variants in a sequential order where each possible variant is unique but similar to the others. 
+While pattern matching allow you to compare a value against series of patterns and executes code based on which pattern matches the compared value.
+
+First we’ll define and use an enum to show how an enum can encode meaning along with data. Next, we’ll explore a particularly useful enum, called Option, which expresses that a value can be either something or nothing. Finally, we’ll look at how pattern matching in the match expression makes it easy to run different code for different values of an enum.

--- a/src/ch06-00-enums-and-pattern-matching.md
+++ b/src/ch06-00-enums-and-pattern-matching.md
@@ -1,6 +1,8 @@
 # Enums and Pattern Matching
-In this chapter, we’ll look at enums and pattern matching.
-
-Enums also referred to as enumerations allow you to define a type by creating a collection of possible variants in a sequential order where each possible variant is unique but similar to the others. While pattern matching allow you to compare a value against series of patterns and executes code based on which pattern matches the compared value.
-
-First we’ll define and use an enum to show how an enum can encode meaning along with data. Next, we’ll explore a particularly useful enum, called Option, which expresses that a value can be either something or nothing. Finally, we’ll look at how pattern matching in the match expression makes it easy to run different code for different values of an enum.
+In this chapter, we’ll look at *enumerations*, also referred to as *enums*.
+Enums allow you to define a type by enumerating its possible *variants*. First,
+we’ll define and use an enum to show how an enum can encode meaning along with
+data. Next, we’ll explore a particularly useful enum, called `Option`, which
+expresses that a value can be either something or nothing. Finally, we’ll look at
+how pattern matching in the `match` expression makes it easy to run different
+code for different values of an enum.

--- a/src/ch06-00-enums-and-pattern-matching.md
+++ b/src/ch06-00-enums-and-pattern-matching.md
@@ -1,7 +1,6 @@
 # Enums and Pattern Matching
-In this chapter, we’ll look at enumerations, also referred to as enums and pattern matching.
+In this chapter, we’ll look at enums and pattern matching.
 
-Enums allow you to define a type by creating a collection possible variants in a sequential order where each possible variant is unique but similar to the others. 
-While pattern matching allow you to compare a value against series of patterns and executes code based on which pattern matches the compared value.
+Enums also referred to as enumerations allow you to define a type by creating a collection of possible variants in a sequential order where each possible variant is unique but similar to the others. While pattern matching allow you to compare a value against series of patterns and executes code based on which pattern matches the compared value.
 
 First we’ll define and use an enum to show how an enum can encode meaning along with data. Next, we’ll explore a particularly useful enum, called Option, which expresses that a value can be either something or nothing. Finally, we’ll look at how pattern matching in the match expression makes it easy to run different code for different values of an enum.

--- a/src/ch06-00-enums-and-pattern-matching.md
+++ b/src/ch06-00-enums-and-pattern-matching.md
@@ -1,4 +1,5 @@
 # Enums and Pattern Matching
+
 In this chapter, we’ll look at *enumerations*, also referred to as *enums*.
 Enums allow you to define a type by enumerating its possible *variants*. First,
 we’ll define and use an enum to show how an enum can encode meaning along with


### PR DESCRIPTION
The current landing page of chapter 6 is empty, normally it should contain an introduction to enums, pattern matching and  why these two were combined in this chapter.

This PR looks to correct that by including a detailed intro to this section as corrected by @enitrat