### PR TITLE
Refactor can_hold function in Rectangle struct 

### DIFF
--- a/listings/ch05-using-structs-to-structure-related-data/listing_04_15_can_hold/src/lib.cairo
+++ b/listings/ch05-using-structs-to-structure-related-data/listing_04_15_can_hold/src/lib.cairo
@@ -33,7 +33,7 @@ impl RectangleImpl of RectangleTrait {
     }
 
     fn can_hold(self: @Rectangle, other: @Rectangle) -> bool {
-        *self.width > *other.width & *self.height > *other.height
+        *self.width > *other.width && *self.height > *other.height
     }
 }
 // ANCHOR_END: trait_impl


### PR DESCRIPTION
Corrected the logical operator in the `can_hold` function of the Rectangle struct to use logical AND (`&&`) instead of bitwise AND (`&`). This ensures the correct comparison of width and height between rectangles.

This change addresses a potential bug where the previous use of the bitwise AND operator led to incorrect results when comparing rectangle sizes. The fix improves the reliability of the can_hold function, particularly in scenarios where rectangles have similar widths or heights.