### PR TITLE
fix: Resolve "Variable not dropped" compilation error in `enums` crate

### DIFF
--- a/src/ch06-01-enums.md
+++ b/src/ch06-01-enums.md
@@ -55,6 +55,7 @@ Running this code would print `quitting`.
 The Option enum is a standard Cairo enum that represents the concept of an optional value. It has two variants: `Some: T` and `None: ()`. `Some: T ` indicates that there's a value of type `T`, while `None` represents the absence of a value.
 
 ```rust,noplayground
+#[derive(Drop)]
 enum Option<T> {
     Some: T,
     None: (),


### PR DESCRIPTION
The commit addresses a compilation error where the compiler screamed `Variable not dropped` indicating a missing drop implementation for the `Option<T>` enum. 

The error was triggered by the use of `enums::Option` in the test module, and it was resolved by adding `#[derive(Drop)]` to the declaration of the `Option<T>` enum.

This change ensures that the `Option<T>` enum implements the necessary drop trait, resolving the "Variable not dropped" error and allowing successful compilation of the `enums` module.