### PR TITLE
fix: Resolve code editor warnings in test module

### DIFF
--- a/listings/ch06-enums-and-pattern-matching/no_listing_03_enum_option/src/lib.cairo
+++ b/listings/ch06-enums-and-pattern-matching/no_listing_03_enum_option/src/lib.cairo
@@ -47,16 +47,24 @@ mod tests {
         let result_i = find_value_iterative(@my_array, value_to_find);
 
         match result {
-            Option::Some(index) => { if index == 1 {
-                'it worked'.print();
-            } },
-            Option::None => { 'not found'.print(); },
+            enums::Option::Some(index) => {
+                if index == 1 {
+                    'it worked'.print();
+                }
+            },
+            enums::Option::None => {
+                'not found'.print();
+            },
         }
         match result_i {
-            Option::Some(index) => { if index == 1 {
-                'it worked'.print();
-            } },
-            Option::None => { 'not found'.print(); },
+            enums::Option::Some(index) => {
+                if index == 1 {
+                    'it worked'.print();
+                }
+            },
+            enums::Option::None => {
+                'not found'.print();
+            },
         }
     }
 }


### PR DESCRIPTION
The commit addresses code editor warnings in the test module related to the use of `Option` in pattern matching. The warnings indicated a mismatch between the expected enum type and the actual type being used in the patterns.

Changes Made:
- Added `enums::` namespace to pattern match against `enums::Option` instead of `core::option::Option` in the test module. This resolves the "Wrong enum in pattern" warning.
- It also Corrected identifier issues in the conditions, ensuring that the code editor recognizes the `index` from the correct namespace.

These changes don't affect the actual compilation, but they resolve the discrepancies flagged by the code editor, making the code more consistent and editor-friendly.